### PR TITLE
Refactored cli resolver options to inherited fields.

### DIFF
--- a/src/main/java/org/tudo/sse/CliInformation.java
+++ b/src/main/java/org/tudo/sse/CliInformation.java
@@ -15,10 +15,6 @@ public class CliInformation {
     private Path name;
     private Path toCoordinates;
     private Path toIndexPos;
-    private boolean index;
-    private boolean pom;
-    private boolean resolveTransitives;
-    private boolean jar;
     private boolean multi;
     private int threads;
 
@@ -30,9 +26,6 @@ public class CliInformation {
         name = Paths.get("lastIndexProcessed");
         toCoordinates = null;
         toIndexPos = null;
-        index = false;
-        pom = false;
-        jar = false;
         multi = false;
     }
 
@@ -84,30 +77,6 @@ public class CliInformation {
         this.toIndexPos = toIndexPos;
     }
 
-    public boolean isIndex() {
-        return index;
-    }
-
-    public void setIndex(boolean index) {
-        this.index = index;
-    }
-
-    public boolean isPom() {
-        return pom;
-    }
-
-    public void setPom(boolean pom) {
-        this.pom = pom;
-    }
-
-    public boolean isJar() {
-        return jar;
-    }
-
-    public void setJar(boolean jar) {
-        this.jar = jar;
-    }
-
     public Path getName() {
         return name;
     }
@@ -122,14 +91,6 @@ public class CliInformation {
 
     public void setMulti(boolean multi) {
         this.multi = multi;
-    }
-
-    public boolean isResolveTransitives() {
-        return resolveTransitives;
-    }
-
-    public void setResolveTransitives(boolean resolveTransitives) {
-        this.resolveTransitives = resolveTransitives;
     }
 
     public int getThreads() {

--- a/src/main/java/org/tudo/sse/OwnImplementation.java
+++ b/src/main/java/org/tudo/sse/OwnImplementation.java
@@ -3,11 +3,24 @@ package org.tudo.sse;
 import org.tudo.sse.model.Artifact;
 
 public class OwnImplementation extends MavenCentralAnalysis {
+
     public OwnImplementation() {
         super();
     }
 
+    public OwnImplementation(boolean resolveIndex, boolean resolvePom, boolean processTransitives, boolean resolveJar) {
+        super();
+        this.resolveIndex = resolveIndex;
+        this.resolvePom = resolvePom;
+        this.processTransitives = processTransitives;
+        this.resolveJar = resolveJar;
+    }
+
     @Override
     public void analyzeArtifact(Artifact toAnalyze) {
+    }
+
+    public void setIndex(boolean resolveIndex) {
+        this.resolveIndex = resolveIndex;
     }
 }

--- a/src/main/java/org/tudo/sse/resolution/ResolverFactory.java
+++ b/src/main/java/org/tudo/sse/resolution/ResolverFactory.java
@@ -1,6 +1,8 @@
 package org.tudo.sse.resolution;
 
 import java.io.IOException;
+import java.net.URI;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.tudo.sse.model.ArtifactIdent;
@@ -11,6 +13,8 @@ import org.tudo.sse.model.ArtifactIdent;
 public class ResolverFactory {
     private final PomResolver pomResolver;
     private final JarResolver jarResolver;
+    protected URI pathToFile;
+    protected boolean output;
 
     public static final Logger log = LogManager.getLogger(ResolverFactory.class);
 

--- a/src/test/resources/MavenAnalysis.json
+++ b/src/test/resources/MavenAnalysis.json
@@ -6,10 +6,7 @@
       "-1",
       "-1",
       "null",
-      "null",
-      "true",
-      "true",
-      "false"
+      "null"
     ],
     [
       "-1",
@@ -17,21 +14,7 @@
       "-1",
       "-1",
       "src/test/resources/localPom.xml",
-      "null",
-      "false",
-      "false",
-      "false"
-    ],
-    [
-      "-1",
-      "-1",
-      "-1",
-      "-1",
-      "null",
-      "null",
-      "false",
-      "false",
-      "true"
+      "null"
     ],
     [
       "-1",
@@ -39,10 +22,7 @@
       "-1",
       "-1",
       "src/test/resources/localPom.xml",
-      "src/test/resources/localPom.xml",
-      "false",
-      "true",
-      "true"
+      "src/test/resources/localPom.xml"
     ],
     [
       "-1",
@@ -50,21 +30,7 @@
       "53245",
       "13243",
       "null",
-      "null",
-      "true",
-      "true",
-      "false"
-    ],
-    [
-      "-1",
-      "-1",
-      "-1",
-      "-1",
-      "null",
-      "null",
-      "true",
-      "false",
-      "true"
+      "null"
     ],
     [
       "-1",
@@ -72,10 +38,7 @@
       "-1",
       "-1",
       "src/test/resources/localPom.xml",
-      "src/test/resources/localPom.xml",
-      "false",
-      "false",
-      "false"
+      "src/test/resources/localPom.xml"
     ],
     [
       "-1",
@@ -83,10 +46,7 @@
       "-1",
       "-1",
       "null",
-      "src/test/resources/localPom.xml",
-      "false",
-      "false",
-      "false"
+      "src/test/resources/localPom.xml"
     ]
   ],
   "readIdentsIn" : [


### PR DESCRIPTION
Some refactoring was done to make specific resolutions easier to perform via overriding the abstract analysis class rather than setting cli everytime.